### PR TITLE
stm/boards: Fix USB PID for SparkFun STM32 MicroMod.

### DIFF
--- a/ports/stm/boards/sparkfun_stm32f405_micromod/mpconfigboard.mk
+++ b/ports/stm/boards/sparkfun_stm32f405_micromod/mpconfigboard.mk
@@ -1,5 +1,5 @@
 USB_VID = 0X1B4F
-USB_PID = 0x0027
+USB_PID = 0x0029
 USB_PRODUCT = "SparkFun STM32 MicroMod Processor"
 USB_MANUFACTURER = "SparkFun Electronics"
 


### PR DESCRIPTION
When I originally created the PR to add support for the SparkFun STM32 MicroMod, SparkFun provided me with the following PID/VID:

PID: 0x0027
VID: 0X1B4F

I missed a follow-up post from SparkFun about 5 months later which provided a corrected PID for this device:

PID: 0x0029

See https://community.sparkfun.com/t/circuitpython-support-for-micromod-stm32-need-usb-pid/42486/5
